### PR TITLE
[#179] 🩹 fix : 관리자 문제 조회 페이지 사이드바 수정

### DIFF
--- a/src/components/ManageReadSidebar.jsx
+++ b/src/components/ManageReadSidebar.jsx
@@ -1,18 +1,17 @@
-// 문제 상세 조회 시 보여줄 사이드바 화면임.
 import React from 'react';
 import styles from '../styles/ManageReadSidebar.module.css';
 
-function ManageReadSidebar() {
+function ManageReadSidebar({ roomName, solvedStudents }) {
   return (
       <aside className={styles.sidebar}>
-        <h2 className={styles.roomTitle}>수학 뽀개기</h2>
+        <h2 className={styles.roomTitle}>{roomName}</h2>
         <ul className={styles.memberList}>
-          <li className={styles.roomOwner}>홍수학 <span className={styles.ownerTag}>선생님</span></li>
           <li className={styles.sectionTitle}>문제 푼 학생</li>
-          <li className={styles.student}>홍준빈 <span className={styles.studentTag}>학생</span></li>
-          <li className={styles.student}>이세원 <span className={styles.studentTag}>학생</span></li>
-          <li className={styles.student}>이지우 <span className={styles.studentTag}>학생</span></li>
-          <li className={styles.student}>신성훈 <span className={styles.studentTag}>학생</span></li>
+          {solvedStudents.map((student, index) => (
+              <li key={index} className={styles.student}>
+                {student.nickName} <span className={styles.studentTag}>학생</span>
+              </li>
+          ))}
         </ul>
       </aside>
   );

--- a/src/pages/ManageReadPage.jsx
+++ b/src/pages/ManageReadPage.jsx
@@ -11,6 +11,7 @@ function ManageReadPage() {
   const [loading, setLoading] = useState(true);
   const [roomName, setRoomName] = useState('');
   const [isPrivate, setIsPrivate] = useState(false);
+  const [solvedStudents, setSolvedStudents] = useState([]);
   const { roomId, questionId } = useParams();
   const navigate = useNavigate();
 
@@ -21,6 +22,7 @@ function ManageReadPage() {
     } else {
       fetchRoomInfo();
       fetchQuestionDetail();
+      fetchSolvedStudents();
     }
   }, [roomId, questionId, navigate]);
 
@@ -57,6 +59,17 @@ function ManageReadPage() {
     }
   };
 
+  const fetchSolvedStudents = async () => {
+    try {
+      const response = await axios.get(`/rooms/${roomId}/question/${questionId}/solved-students`);
+      if (response.data && response.data.data) {
+        setSolvedStudents(response.data.data);
+      }
+    } catch (error) {
+      console.error('Failed to fetch solved students:', error);
+    }
+  };
+
   const handleQuestionListClick = () => {
     navigate(`/room/${roomId}/manageMain`);
   };
@@ -88,7 +101,7 @@ function ManageReadPage() {
 
   return (
       <div className={styles.manageReadPage}>
-        <ManageReadSidebar />
+        <ManageReadSidebar roomName={roomName} solvedStudents={solvedStudents} />
         <div className={styles.mainContent}>
           <ManageMainHeaderNav
               roomId={roomId}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #179 
> Close #179 

## 📑 작업 내용
> - ![image](https://github.com/user-attachments/assets/ca811c48-39de-4411-8326-16cc90c6337b)
> - ![image](https://github.com/user-attachments/assets/e420d24c-2e1f-4222-bdc8-382549fbb115)
> - 관리자 문제 조회 페이지 사이드바 수정 / 문제 푼 학생 읽어와서 표시, 선생님은 문제 못 풀게 수정

## 💭 리뷰 요구사항
>
